### PR TITLE
fix: resolve goreleaser build failure in GitHub Actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,8 +28,8 @@ jobs:
         uses: goreleaser/goreleaser-action@v4.1.1
         with:
           github_token: ${{ secrets.GH_PUBLISH_SECRETS }}
-          version: v1.14.0
-          args: release --skip-publish --rm-dist --snapshot
+          version: v2.8.0
+          args: release --clean --snapshot
 
   BuildImage:
     runs-on: ubuntu-22.04

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   Test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Set up Go
         uses: actions/setup-go@v3
@@ -17,7 +17,7 @@ jobs:
           make test
 
   Build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Set up Go
         uses: actions/setup-go@v3
@@ -32,7 +32,7 @@ jobs:
           args: release --skip-publish --rm-dist --snapshot
 
   BuildImage:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Set up Go
         uses: actions/setup-go@v3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,7 +32,7 @@ jobs:
           args: release --skip-publish --rm-dist --snapshot
 
   BuildImage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Set up Go
         uses: actions/setup-go@v3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   Test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Set up Go
         uses: actions/setup-go@v3
@@ -17,7 +17,7 @@ jobs:
           make test
 
   Build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Set up Go
         uses: actions/setup-go@v3

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   UpdateReleaseDraft:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: release-drafter/release-drafter@v5
         env:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   UpdateReleaseDraft:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v5
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   goreleaser:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3.6.0
@@ -50,7 +50,7 @@ jobs:
           oras push ${{ env.REGISTRY }}/linuxsuren/atest-ext-store-git:${TAG#v} */*
 
   image:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3.0.0
@@ -81,7 +81,7 @@ jobs:
           cache-to: type=gha,mode=max
 
   image-dockerhub:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3.0.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,10 +34,10 @@ jobs:
           docker login --username linuxsuren --password ${{secrets.DOCKER_HUB_PUBLISH_SECRETS}}
           docker login ${{ env.REGISTRY }}/linuxsuren --username linuxsuren --password ${{secrets.GH_PUBLISH_SECRETS}}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2.9.1
+        uses: goreleaser/goreleaser-action@v4.1.1
         if: github.ref != 'refs/heads/master'
         with:
-          version: latest
+          version: v2.8.0
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PUBLISH_SECRETS }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   goreleaser:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3.6.0
@@ -38,7 +38,7 @@ jobs:
         if: github.ref != 'refs/heads/master'
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PUBLISH_SECRETS }}
       - name: Upload via oras
@@ -50,7 +50,7 @@ jobs:
           oras push ${{ env.REGISTRY }}/linuxsuren/atest-ext-store-git:${TAG#v} */*
 
   image:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3.0.0
@@ -81,7 +81,7 @@ jobs:
           cache-to: type=gha,mode=max
 
   image-dockerhub:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3.0.0

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,6 @@
 # This is an example .goreleaser.yml file with some sensible defaults.
 # Make sure to check the documentation at https://goreleaser.com
+version: 2
 before:
   hooks:
     # You may remove this if you don't use go modules.
@@ -20,17 +21,17 @@ builds:
       - -s
 archives:
   - name_template: "{{ .Binary }}-{{ .Os }}-{{ .Arch }}"
-    builds:
+    ids:
       - atest-store-git
     format_overrides:
       - goos: windows
-        format: zip
+        formats: ['zip']
     files:
       - README.md
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
# Fix for Issue [#525](https://github.com/LinuxSuRen/api-testing/issues/525)

## Deprecation Notices Addressed

1. Replaced deprecated `--rm-dist` flag with the recommended `--clean` flag in `release.yaml` , as per [GoReleaser deprecation notice](https://goreleaser.com/deprecations/#-rm-dist)

```diff
- args: release --rm-dist
+ args: release --clean
```

2. Updated GitHub Actions workflow to use `ubuntu-latest` instead of the deprecated `ubuntu-20.04` image, which has been [removed by GitHub](https://github.com/actions/runner-images/issues/11101)

```diff
- runs-on: ubuntu-20.04
+ runs-on: ubuntu-latest
```


## Format Standardization

1. Updated `.goreleaser` configuration to use the latest `version: 2` format

```diff
+ version: 2
```

2. Fixed several deprecated configurations identified during dry run testing:
   - `snapshot.name_template`
   - `archives.builds`
   - `archives.format_overrides.format`

   Full details available in this [job log](https://github.com/teriyakisushi/atest-ext-store-git/actions/runs/14681104624/job/41203885796)

## Testing Results

- Verified changes locally using the `act` tool to simulate GitHub Actions (excluding jobs requiring authentication)

![act_test_result](https://github.com/user-attachments/assets/04f62d2a-743c-4fc3-9633-852575aeb69b)

- Successfully tested on my fork at [](https://github.com/teriyakisushi/atest-ext-store-git/tree/teriyakisushi) with GitHub Actions running properly, See this [job](https://github.com/teriyakisushi/atest-ext-store-git/actions/runs/14693217918/job/41231375236) details.

## Questions

1. Would you prefer to accept these updated format standards, or would you prefer to maintain consistency with other plugins by keeping the original format?

2. Regarding GitHub Actions runner: I've used `ubuntu-latest` to replace the deprecated `ubuntu-20.04`. Would you prefer I specifically use `ubuntu-22.04` instead of `ubuntu-latest`?